### PR TITLE
Increase timeout for publishing layer

### DIFF
--- a/scripts/deploy-layer.py
+++ b/scripts/deploy-layer.py
@@ -4,6 +4,7 @@ import click
 import hashlib
 
 from boto3.session import Session as boto3_session
+from botocore.client import Config
 
 AWS_REGIONS = [
     "eu-central-1",
@@ -38,11 +39,14 @@ def main(gdalversion, pythonversion, layername):
 
     session = boto3_session()
 
+    # Increase connection timeout to work around timeout errors
+    config = Config(connect_timeout=6000, retries={'max_attempts': 5})
+
     click.echo(f"Deploying {layer_name}", err=True)
     for region in AWS_REGIONS:
         click.echo(f"AWS Region: {region}", err=True)
 
-        client = session.client("lambda", region_name=region)
+        client = session.client("lambda", region_name=region, config=config)
 
         res = client.list_layer_versions(
             CompatibleRuntime=runtime, LayerName=layer_name


### PR DESCRIPTION
I kept getting
```
botocore.exceptions.ConnectionClosedError: Connection was closed before we received a valid response from endpoint URL: "https://lambda.eu-central-1.amazonaws.com/2018-10-31/layers/gdal24-py37-geo/versions".
```
errors when trying to publish layers to lambda. Maybe you just have a faster internet upload speed than I do, but I had to increase the timeout to be able to upload a layer.